### PR TITLE
Core, Storage, ViewModels, View - Add delete feature

### DIFF
--- a/ToDo.API/ITaskController.cs
+++ b/ToDo.API/ITaskController.cs
@@ -17,5 +17,7 @@ namespace ToDo.API
         /// <param name="description">Description of the task</param>
         /// <returns>Newly created task</returns>
         Task<IToDoTask> AddTask(string description);
+
+        Task<bool> DeleteTask(long task);
     }
 }

--- a/ToDo.API/ITaskStorage.cs
+++ b/ToDo.API/ITaskStorage.cs
@@ -43,5 +43,7 @@ namespace ToDo.API
         /// </summary>
         /// <returns>Total number of tasks in storage</returns>
         Task<long> GetTotalNumberOfTasks();
+
+        Task<bool> DeleteTask(long id);
     }
 }

--- a/ToDo.Core/TaskController.cs
+++ b/ToDo.Core/TaskController.cs
@@ -68,5 +68,10 @@ namespace ToDo.Core
             retrivedTask.PropertyChanged += OnTaskAttributesChanged;
             return retrivedTask;
         }
+
+        public async Task<bool> DeleteTask(long idToDelete)
+        {
+            return await _taskStorage.DeleteTask(idToDelete);
+        }
     }
 }

--- a/ToDo.Storage/SQLiteStorage.cs
+++ b/ToDo.Storage/SQLiteStorage.cs
@@ -158,5 +158,27 @@ namespace ToDo.Storage
                 return reader.GetInt32(0);
             }
         }
+
+        public async Task<bool> DeleteTask(long id)
+        {
+            var deleteTaskCommand = _sqLiteConnection.CreateCommand();
+            deleteTaskCommand.CommandText =
+                @"
+                        DELETE
+                        FROM ""Tasks""
+                        WHERE id = $id
+                    ";
+            deleteTaskCommand.Parameters.AddWithValue("$id", id);
+            bool taskDeleted = false;
+            try
+            {
+                taskDeleted = await deleteTaskCommand.ExecuteNonQueryAsync() == 1;
+            }
+            catch
+            {
+            }
+
+            return taskDeleted;
+        }
     }
 }

--- a/ToDo.Tests/Core/TaskControllerTests.cs
+++ b/ToDo.Tests/Core/TaskControllerTests.cs
@@ -59,6 +59,12 @@ namespace ToDo.Tests.Core
                     _tasks.Find(x => x.Id == id).HasCompleted = hasCompleted;
                     return true;
                 });
+            _mockTaskStorage.Setup(storage => storage.DeleteTask(It.IsAny<long>()))
+                .ReturnsAsync((long id) =>
+                {
+                    var foundTask = _tasks.Find(x => x.Id == id);
+                    return _tasks.Remove(foundTask);
+                });
         }
 
         [TestCleanup]
@@ -207,6 +213,29 @@ namespace ToDo.Tests.Core
 
             // then
             Assert.AreEqual(newHasCompleted, retrivedTasks[1].HasCompleted);
+        }
+
+        [TestMethod]
+        public async Task OnDeleteTask_WithIDPresent_DeleteingIsSuccessful() {
+            // given
+            long idToDelete = 1;
+            _tasks.Add(CreateNewMockTask(idToDelete, "This is test task 1", false));
+
+            // when
+            bool result = await _taskController.DeleteTask(idToDelete);
+
+            // then
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public async Task OnDeleteTask_WithIDNotPresent_DeleteingIsUnsuccessful()
+        {
+            // when
+            bool result = await _taskController.DeleteTask(1);
+
+            // then
+            Assert.IsFalse(result);
         }
     }
 }

--- a/ToDo.Tests/Storage/StorageTestsBase.cs
+++ b/ToDo.Tests/Storage/StorageTestsBase.cs
@@ -128,11 +128,43 @@ namespace ToDo.Tests.Storage
             const string description = "new description";
             bool result = await _storage.UpdateTaskDescription(newTask.Id, "new description");
 
-            // given
+            // then
             Assert.IsTrue(result);
             var taskFromStorage = GetTaskWithId(newTask.Id);
             Assert.AreEqual(description, taskFromStorage.Description);
             Assert.AreEqual(newTask.HasCompleted, taskFromStorage.HasCompleted);
+        }
+        #endregion
+
+        #region Delete Task
+        [TestMethod]
+        public async Task OnDeleteTask_WithIDPresent_ReturnsTrue_DeletesTaskInStorage()
+        {
+            // given
+            long id = 1;
+            var newTask = CreateNewMockTask(id, "old description", false);
+            AddTaskToTestStorage(newTask);
+
+            // when
+            var result = await _storage.DeleteTask(id);
+
+            // then
+            Assert.AreEqual(true, result);
+            //Assert.
+
+        }
+
+        [TestMethod]
+        public async Task OnDeleteTask_WithIDNotPresent_ReturnsFalse_DoesNotChangeNumberOfTasksInStorage()
+        {
+            // given
+            long id = 1;
+
+            // when
+            var result = await _storage.DeleteTask(id);
+
+            // then
+            Assert.AreEqual(false, result);
         }
         #endregion
     }

--- a/ToDo.ViewModels/EditableTaskViewModel.cs
+++ b/ToDo.ViewModels/EditableTaskViewModel.cs
@@ -32,6 +32,7 @@ namespace ToDo.ViewModels
 
         public event Action<string> IncorrectDescription;
         internal event Func<string, Action<IToDoTask>, Task> AddTaskClicked;
+        internal event Func<EditableTaskViewModel, long, Task> DeleteTaskClicked;
 
         public TaskState CurrentTaskState
         {
@@ -99,6 +100,11 @@ namespace ToDo.ViewModels
             {
                 IncorrectDescription?.Invoke("Write a description for task before adding");
             }
+        }
+
+        public async Task DeleteTask()
+        {
+            await DeleteTaskClicked?.Invoke(this, _task.Id);
         }
 
         public void DiscardChanges()

--- a/ToDo.ViewModels/MainPageViewModel.cs
+++ b/ToDo.ViewModels/MainPageViewModel.cs
@@ -42,6 +42,14 @@ namespace ToDo.ViewModels
             }
         }
 
+        private async Task DeleteTask(EditableTaskViewModel editableTaskViewModel, long id)
+        {
+            _toBeAddedTask.DeleteTaskClicked -= DeleteTask;
+            await _controller.DeleteTask(id);
+            _unfilteredTasks.Remove(editableTaskViewModel);
+            _tasks.Remove(editableTaskViewModel);
+        }
+
         public async Task Initialize(ITaskController controller)
         {
             _controller = controller;
@@ -49,6 +57,7 @@ namespace ToDo.ViewModels
             foreach (var task in await _controller.GetAllTasks())
             {
                 var taskViewModel = new EditableTaskViewModel(task.Value);
+                taskViewModel.DeleteTaskClicked += DeleteTask;
                 _unfilteredTasks.Add(taskViewModel);
                 _tasks.Add(taskViewModel);
             }
@@ -73,6 +82,7 @@ namespace ToDo.ViewModels
             if (newTask != null)
             {
                 saveTaskFromStorage(newTask);
+                ToBeAddedTask.DeleteTaskClicked += DeleteTask;
                 _unfilteredTasks.Add(ToBeAddedTask);
                 if (_doesSatisfySearchQuery(ToBeAddedTask.Description))
                 {
@@ -80,7 +90,7 @@ namespace ToDo.ViewModels
                 }
 
                 ToBeAddedTask = new EditableTaskViewModel();
-
+                
             }
         }
     }

--- a/ToDo.Views/Controls/EditableTask.xaml
+++ b/ToDo.Views/Controls/EditableTask.xaml
@@ -52,14 +52,20 @@
                 <muxc:SymbolIconSource Symbol="Rename" />
             </muxc:TeachingTip.IconSource>
         </muxc:TeachingTip>
-        <Button
-            Grid.Column="2"
-            HorizontalAlignment="Right"
-            IsTabStop="False"
-            Style="{StaticResource TextBlockButtonStyle}"
-            Tapped="OnTaskStateUpdateButtonClicked">
-            <SymbolIcon x:Name="TaskStateUpdateIcon" Symbol="Edit" />
-        </Button>
+        <StackPanel Grid.Column="2" HorizontalAlignment="Right" Orientation="Horizontal">
+            <Button
+                IsTabStop="False"
+                Style="{StaticResource TextBlockButtonStyle}"
+                Tapped="OnTaskStateUpdateButtonClicked">
+                <SymbolIcon x:Name="TaskStateUpdateIcon" Symbol="Edit" />
+            </Button>
+            <Button
+                IsTabStop="False"
+                Style="{StaticResource TextBlockButtonStyle}"
+                Tapped="OnTaskDeleteButtonClicked">
+                <SymbolIcon x:Name="TaskUpdateIcon" Symbol="Delete" />
+            </Button>
+        </StackPanel>
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="TaskStates">
                 <VisualState x:Name="AddingTask">

--- a/ToDo.Views/Controls/EditableTask.xaml.cs
+++ b/ToDo.Views/Controls/EditableTask.xaml.cs
@@ -131,5 +131,10 @@ namespace ToDo.Views.Controls
                 await ViewModel.AcceptChanges();
             }
         }
+
+        private async void OnTaskDeleteButtonClicked(object sender, TappedRoutedEventArgs e)
+        {
+            await ViewModel.DeleteTask();
+        }
     }
 }


### PR DESCRIPTION
Added a new button to the `Delete` task next to the existing `Update` button. 

# Cases to test
- Deleting task should not freeze UI
- Deleted task should not persist in following lifecycle of app
- Should be able to add new task in a new lifecycle 